### PR TITLE
feat: add a route to dump all stations

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -24,6 +24,14 @@ async def stations():
         data = json.load(j)
     return data
 
+@app.get("/api/v1/stations/data", tags=["stations"])
+async def stations_data():
+    """
+    Get a list of all stations with data
+    """
+    with open("/data/station_data.json") as j:
+        data = json.load(j)
+    return data
 
 @app.get("/api/v1/station/{id_or_name}", tags=["stations"])
 async def station(id_or_name):


### PR DESCRIPTION
I would like to avoid spamming your endpoints to get informations I need so I added a route.
I didn't where to edit the `/docs` page, I suppose it's automagically generated.
I wasn't able to test it as it requires the FOEN access.